### PR TITLE
Feature: Updated labeler script to add "status: need to test locally" for curriculum changes

### DIFF
--- a/addTestLocallyLabel.js
+++ b/addTestLocallyLabel.js
@@ -9,10 +9,7 @@ const { saveToFile, openJSONFile } = require('./fileFunctions');
 const { octokitConfig, octokitAuth } = require('./octokitConfig');
 const octokit = require('@octokit/rest')(octokitConfig);
 const { getOpenPrs, getPrRange } = require('./getOpenPrs');
-const { validLabels } = require('./validLabels');
 const { addLabels } = require('./addLabels');
-const { guideFolderChecks } = require('./guideFolderChecks');
-const { addComment } = require('./addComment');
 const { rateLimiter, savePrData } = require('./utils');
 
 octokit.authenticate(octokitAuth);
@@ -20,7 +17,7 @@ octokit.authenticate(octokitAuth);
 const { PrProcessingLog } = require('./prProcessingLog');
 const log = new PrProcessingLog();
 
-const prPropsToGet = ['number', 'labels', 'user'];
+const prPropsToGet = ['number', 'labels'];
 
 (async () => {
   const { firstPR, lastPR } = await getPrRange();
@@ -28,46 +25,17 @@ const prPropsToGet = ['number', 'labels', 'user'];
 
   if (openPRs.length) {
     savePrData(openPRs, firstPR, lastPR);
-
     log.start();
     console.log('Starting labeling process...');
     for (let count = 0; count < openPRs.length; count++) {
-      let { number, labels, user: { login: username } } = openPRs[count];
-      const { data: prFiles } = await octokit.pullRequests.getFiles({ owner, repo, number });
-      log.add(number, 'labels', 'comment');
+      let { number, labels } = openPRs[count];
+      log.add(number, 'labels');
       const labelsToAdd = {}; // holds potential labels to add based on file path
-
-      const guideFolderErrorsComment = guideFolderChecks(prFiles, username);
-      if (guideFolderErrorsComment) {
-        log.update(number, 'comment', guideFolderErrorsComment);
-        if (process.env.PRODUCTION_RUN === 'true') {
-          const result = await addComment(number, guideFolderErrorsComment);
-        }
-        await rateLimiter(process.env.RATELIMIT_INTERVAL | 1500);
-        labelsToAdd['status: needs update'] = 1;
-      }
-      else {
-        log.update(number, 'comment', 'not added');
-      }
-
       const existingLabels = labels.map(({ name }) => name);
-
-      prFiles.forEach(({ filename }) => {
-        /* remove '/challenges' from filename so language variable hold the language */
-        const filenameReplacement = filename.replace(/^curriculum\/challenges\//, 'curriculum\/');
-        const regex = /^(docs|curriculum|guide)(?:\/)(arabic|chinese|portuguese|russian|spanish)?\/?/
-        const [ _, articleType, language ] = filenameReplacement.match(regex) || []; // need an array to pass to labelsAdder
-
-        if (articleType && validLabels[articleType]) {
-          labelsToAdd[validLabels[articleType]] = 1
-        }
-        if (language && validLabels[language]) {
-          labelsToAdd[validLabels[language]] = 1
-        }
-        if (articleType === 'curriculum') {
-          labelsToAdd['status: need to test locally'] = 1;
-        }
-      })
+      if (existingLabels.includes('scope: curriculum')) {
+        labelsToAdd['status: need to test locally'] = 1;
+      }
+      log.add(number, 'labels');
 
       /* this next section only adds needed labels which are NOT currently on the PR. */
       const newLabels = Object.keys(labelsToAdd).filter(label => !existingLabels.includes(label));
@@ -75,8 +43,8 @@ const prPropsToGet = ['number', 'labels', 'user'];
         log.update(number, 'labels', newLabels);
         if (process.env.PRODUCTION_RUN === 'true') {
           addLabels(number, newLabels, log);
+          await rateLimiter(process.env.RATELIMIT_INTERVAL | 1500);
         }
-        await rateLimiter(process.env.RATELIMIT_INTERVAL | 1500);
       }
       else {
         log.update(number, 'labels', 'none added');

--- a/fileFunctions.js
+++ b/fileFunctions.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
 const saveToFile = (fileName, data) => {
-  fs.writeFile(fileName, data, err => {
+  fs.writeFileSync(fileName, data, err => {
     if (err) { return console.log(err) }
   });
 }

--- a/frontmatterChecks.js
+++ b/frontmatterChecks.js
@@ -1,0 +1,13 @@
+const matter = require('gray-matter');
+
+const checkFrontmatter = (fullPath, isTranslation, content) => {
+  const { data: frontmatter } = matter(content);
+  let errors = [];
+  if (!frontmatter || _.isEmpty(frontmatter) || !frontmatter.title) {
+    errors.push(`${fullPath} is missing \`title key\` frontmatter.`);
+  }
+  if (isTranslation && !frontmatter.localeTitle) {
+    errors.push(`${fullPath} is missing \`localeTitle\`frontmatter.`);
+  }
+  return errors;
+}

--- a/prProcessingLog.js
+++ b/prProcessingLog.js
@@ -10,7 +10,6 @@ class PrProcessingLog {
     this._lastPRlogged = null;
     this._finish = null;
     this._prs = {};
-    //path.resolve(__dirname, '../../../guide');
     this._logfile = path.resolve(__dirname, './work-logs/open-prs-processed.json');
   }
 

--- a/prProcessingLog.js
+++ b/prProcessingLog.js
@@ -10,7 +10,11 @@ class PrProcessingLog {
     this._lastPRlogged = null;
     this._finish = null;
     this._prs = {};
-    this._logfile = path.resolve(__dirname, './work-logs/open-prs-processed.json');
+    this._logfile = path.resolve(__dirname, `./work-logs/${this.getRunType()}_open-prs-processed.json`);
+  }
+
+  getRunType() {
+    return process.env.PRODUCTION_RUN === 'true' ? 'production' : 'test';
   }
 
   import() {

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,20 @@
+const path = require('path');
+const fs = require('fs');
+const formatDate = require('date-fns/format');
+
+const { saveToFile } = require('./fileFunctions');
+
 const rateLimiter = (delay) => {
   return new Promise(resolve => setTimeout(() => resolve(true), delay));
 };
 
-module.exports = { rateLimiter };
+const savePrData = (openPRs, firstPR, lastPR) => {
+  const now = formatDate(new Date(), 'YYYY-MM-DDTHHmmss');
+  const filename = path.resolve(__dirname, `./work-logs/openprs_${firstPR}-${lastPR}_${now}.json`);
+  console.log(`# of PRs Retrieved: ${openPRs.length}`);
+  console.log(`PR Range: ${firstPR} - ${lastPR}`);
+  saveToFile(filename, JSON.stringify(openPRs));
+  console.log(`Data saved in file: ${filename}`);
+};
+
+module.exports = { rateLimiter, savePrData };


### PR DESCRIPTION
This PR adds a new one-off script which will add the label "status: need to test locally" to all PRs involving the curriculum.  Also, the labelOpenPrs.js has been updated with logic to add this same functionality.

Other minor tweaks:

- The addition of a new function savePrData (in utlis.js) which creates the initial log for the PRs downloaded and console logs information about the results of the data received.
- Modified the saving of files to be synchronous to deal with a problem where sometime the log file was not showing a finish date/time.
-Added logic based on the process.env.PRODUCTION_RUN variable which prepends either "production" or "test" to the open-prs-processed.json file.  This should make it easier to keep identify the logs.
- Created new function frontmatterChecks.js which will validate if the frontmatter exists for a given string of the file contents passed to it.  This function will be used in another part of the labeler which will actually get the file contents (yet to be written).