### PR TITLE
Fix corrected config.oneoff.productionRun issue

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -27,8 +27,7 @@ const envVarsSchema = Joi.object({
   PRIVATE_KEY: Joi.string().required(),
   WEBHOOK_SECRET: Joi.string().required(),
   CLIENT_ID: Joi.string().required(),
-  CLIENT_SECRET: Joi.string().required(),
-  SKIP_PREFLIGHT_CHECK: Joi.boolean().default(true)
+  CLIENT_SECRET: Joi.string().required()
 })
   .unknown()
   .required();

--- a/lib/pr-tasks/labeler.js
+++ b/lib/pr-tasks/labeler.js
@@ -41,7 +41,7 @@ const labeler = async (
     return !existingLabels.includes(label);
   });
   if (newLabels.length) {
-    if (config.github.productionRun === 'true') {
+    if (config.oneoff.productionRun) {
       addLabels(number, newLabels);
     }
     await rateLimiter();

--- a/lib/utils/processing-log.js
+++ b/lib/utils/processing-log.js
@@ -21,7 +21,7 @@ class ProcessingLog {
   }
 
   getRunType() {
-    return config.github.productionRun === 'true' ? 'production' : 'test';
+    return config.oneoff.productionRun ? 'production' : 'test';
   }
 
   export() {

--- a/lib/validation/guide-folder-checks/index.js
+++ b/lib/validation/guide-folder-checks/index.js
@@ -23,7 +23,7 @@ const guideFolderChecks = async (number, prFiles, user) => {
 
   if (prErrors.length) {
     const comment = createErrorMsg(prErrors, user);
-    if (config.github.productionRun === 'true') {
+    if (config.oneoff.productionRun) {
       await addComment(number, comment);
     }
     await rateLimiter();

--- a/one-off-scripts/add-comment-on-frontmatter-issues.js
+++ b/one-off-scripts/add-comment-on-frontmatter-issues.js
@@ -53,7 +53,7 @@ const labeler = async(
     return !existingLabels.includes(label);
   });
   if (newLabels.length) {
-    if (config.github.productionRun === 'true') {
+    if (config.oneoff.productionRun) {
       addLabels(number, newLabels);
       await rateLimiter();
     }
@@ -90,7 +90,7 @@ const guideFolderChecks = async(number, prFiles, user) => {
 
   if (prErrors.length) {
     const comment = createErrorMsg(prErrors, user);
-    if (config.github.productionRun === 'true') {
+    if (config.oneoff.productionRun) {
       await addComment(number, comment);
       await rateLimiter();
     }

--- a/one-off-scripts/add-test-locally-label.js
+++ b/one-off-scripts/add-test-locally-label.js
@@ -36,7 +36,7 @@ const log = new ProcessingLog('all-locally-tested-labels');
 
       if (newLabels.length) {
         log.add(number, { number, labels: newLabels });
-        if (config.github.productionRun === 'true') {
+        if (config.oneoff.productionRun) {
           addLabels(number, newLabels, log);
           await rateLimiter();
         }

--- a/one-off-scripts/close-open-specific-failures.js
+++ b/one-off-scripts/close-open-specific-failures.js
@@ -28,7 +28,7 @@ const getUserInput = async() => {
     for (let { number, errorDesc } of prs) {
       if (errorDesc !== 'unknown error') {
         log.add(number, { number, closedOpened: true, errorDesc });
-        if (config.github.productionRun === 'true') {
+        if (config.oneoff.productionRun) {
           await closeOpen(number);
           await rateLimiter(90000);
         }


### PR DESCRIPTION
In an earlier PR I use `joi` to make PRODUCTION_RUN environment variables a Boolean, but did not change to the correct reference and did not change the code logic to compare to a Boolean instead of a String value (as it had been before).  This PR corrects that logic, so that the one-off scripts will work in a production mode again.  Also, removed the now unnecessary ` SKIP_PREFLIGHT_CHECK` environment variable from the `probot/.env` file.