### PR TITLE
Fix: modified data-seed.js to not drop system.indexes

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -27,8 +27,7 @@ const envVarsSchema = Joi.object({
   PRIVATE_KEY: Joi.string().required(),
   WEBHOOK_SECRET: Joi.string().required(),
   CLIENT_ID: Joi.string().required(),
-  CLIENT_SECRET: Joi.string().required(),
-  SKIP_PREFLIGHT_CHECK: Joi.boolean().default(true)
+  CLIENT_SECRET: Joi.string().required()
 })
   .unknown()
   .required();

--- a/one-off-scripts/add-comment-on-frontmatter-issues.js
+++ b/one-off-scripts/add-comment-on-frontmatter-issues.js
@@ -35,7 +35,7 @@ octokit.authenticate(octokitAuth);
 
 const log = new ProcessingLog('all-frontmatter-checks');
 
-const labeler = async(
+const labeler = async (
   number,
   prFiles,
   currentLabels,
@@ -74,11 +74,11 @@ const checkPath = (fullPath, fileContent) => {
   return errorMsgs.concat(frontMatterErrMsgs);
 };
 
-const guideFolderChecks = async(number, prFiles, user) => {
+const guideFolderChecks = async (number, prFiles, user) => {
   let prErrors = [];
   for (let { filename: fullPath, raw_url: fileUrl } of prFiles) {
     let newErrors;
-    if ((/^guide\//).test(fullPath)) {
+    if (/^guide\//.test(fullPath)) {
       const response = await fetch(fileUrl);
       const fileContent = await response.text();
       newErrors = checkPath(fullPath, fileContent);
@@ -100,7 +100,7 @@ const guideFolderChecks = async(number, prFiles, user) => {
   }
 };
 
-(async() => {
+(async () => {
   const { totalPRs, firstPR, lastPR } = await getUserInput();
   const prPropsToGet = ['number', 'labels', 'user'];
   const { openPRs } = await getPRs(totalPRs, firstPR, lastPR, prPropsToGet);

--- a/one-off-scripts/add-test-locally-label.js
+++ b/one-off-scripts/add-test-locally-label.js
@@ -12,7 +12,7 @@ const { rateLimiter, ProcessingLog } = require('../lib/utils');
 
 const log = new ProcessingLog('all-locally-tested-labels');
 
-(async() => {
+(async () => {
   const { totalPRs, firstPR, lastPR } = await getUserInput();
   const prPropsToGet = ['number', 'labels'];
   const { openPRs } = await getPRs(totalPRs, firstPR, lastPR, prPropsToGet);

--- a/one-off-scripts/close-open-specific-failures.js
+++ b/one-off-scripts/close-open-specific-failures.js
@@ -5,7 +5,7 @@ const { openJSONFile, ProcessingLog, rateLimiter } = require('../lib/utils');
 const log = new ProcessingLog('prs-closed-reopened');
 
 log.start();
-const getUserInput = async() => {
+const getUserInput = async () => {
   let filename = process.argv[2];
 
   if (!filename) {
@@ -20,7 +20,7 @@ const getUserInput = async() => {
   return { prs };
 };
 
-(async() => {
+(async () => {
   const { prs } = await getUserInput();
   return prs;
 })()

--- a/one-off-scripts/find-failures.js
+++ b/one-off-scripts/find-failures.js
@@ -22,7 +22,7 @@ const errorsToFind = [
   }
 ];
 
-(async() => {
+(async () => {
   const { totalPRs, firstPR, lastPR } = await getUserInput();
   const prPropsToGet = ['number', 'labels', 'head'];
   const { openPRs } = await getPRs(totalPRs, firstPR, lastPR, prPropsToGet);

--- a/one-off-scripts/get-unknown-repo-prs.js
+++ b/one-off-scripts/get-unknown-repo-prs.js
@@ -8,7 +8,7 @@ octokit.authenticate(octokitAuth);
 
 const log = new ProcessingLog('unknown-repo-prs-with-merge-conflicts');
 log.start();
-(async() => {
+(async () => {
   const { totalPRs, firstPR, lastPR } = await getUserInput('all');
   const prPropsToGet = ['number', 'user', 'head'];
   const { openPRs } = await getPRs(totalPRs, firstPR, lastPR, prPropsToGet);
@@ -38,7 +38,7 @@ log.start();
     throw 'There were no open PRs received from Github';
   }
 })()
-  .then(async() => {
+  .then(async () => {
     log.finish();
     console.log('Finished finding unknown repo PRs with merge conflicts');
   })

--- a/one-off-scripts/sweeper.js
+++ b/one-off-scripts/sweeper.js
@@ -25,7 +25,7 @@ const log = new ProcessingLog('sweeper');
 
 log.start();
 console.log('Sweeper started...');
-(async() => {
+(async () => {
   const { totalPRs, firstPR, lastPR } = await getUserInput();
   const prPropsToGet = ['number', 'labels', 'user'];
   const { openPRs } = await getPRs(totalPRs, firstPR, lastPR, prPropsToGet);

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "postinstall": "npm run bootstrap",
     "format": "prettier --write es5 ./**/*.{js,json} && npm run lint",
     "lint": "eslint ./**/*.js --fix",
-    "start": "lerna run start --stream",
-    "seed": "lerna run seed --stream",
+    "start": "cd probot && npm start && cd ../",
+    "seed": "cd probot && npm run seed && cd ../",
     "dev": "nodemon"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "postinstall": "npm run bootstrap",
     "format": "prettier --write es5 ./**/*.{js,json} && npm run lint",
     "lint": "eslint ./**/*.js --fix",
-    "start": "lerna run start",
-    "seed": "cd probot && npm run seed && cd ..",
+    "start": "lerna run start --stream",
+    "seed": "lerna run seed --stream",
     "dev": "nodemon"
   },
   "devDependencies": {

--- a/probot/index.js
+++ b/probot/index.js
@@ -49,11 +49,12 @@ async function probotPlugin(robot) {
   app.use(function(err, req, res) {
     res.status(err.status || 500).send(err.message);
   });
+
   // connect to mongo db
   const mongoUri = config.mongo.host;
+
   const promise = mongoose.connect(
-    encodeURI(mongoUri),
-    { useNewUrlParser: true }
+    mongoUri, { useNewUrlParser: true }
   );
   promise
     .then(() => {

--- a/probot/server/models/index.js
+++ b/probot/server/models/index.js
@@ -14,6 +14,11 @@ const info = new mongoose.Schema({
   prRange: String
 });
 
-const PR = mongoose.model('PR', pr, 'openprs');
-const INFO = mongoose.model('INFO', info, 'info');
-module.exports = { PR, INFO };
+const dbCollections = {
+   pr: 'openprs',
+   info: 'info'
+};
+
+const PR = mongoose.model('PR', pr, dbCollections['pr']);
+const INFO = mongoose.model('INFO', info, dbCollections['info']);
+module.exports = { PR, INFO, dbCollections };

--- a/probot/server/tools/seed-db.js
+++ b/probot/server/tools/seed-db.js
@@ -9,6 +9,7 @@ const db = mongoose.connect(
   mongoUri,
   { useNewUrlParser: true }
 );
+
 const { PR, INFO } = require('../models');
 
 db.then(() => {
@@ -19,9 +20,11 @@ db.then(() => {
     }
     if (names) {
       names.forEach(({ name }) => {
-        mongoose.connection.db
-          .dropCollection(name)
-          .catch(err => console.log(err));
+        if (name !== 'system.indexes') {
+          mongoose.connection.db
+            .dropCollection(name)
+            .catch(err => console.log(err));
+        }
       });
     }
   });

--- a/probot/server/tools/seed-db.js
+++ b/probot/server/tools/seed-db.js
@@ -10,7 +10,7 @@ const db = mongoose.connect(
   { useNewUrlParser: true }
 );
 
-const { PR, INFO } = require('../models');
+const { PR, INFO, dbCollections } = require('../models');
 
 db.then(() => {
   // remove all existing collections from db
@@ -19,8 +19,9 @@ db.then(() => {
       throw err;
     }
     if (names) {
+      const collectionNames = Object.values(dbCollections);
       names.forEach(({ name }) => {
-        if (name !== 'system.indexes') {
+        if (collectionNames.includes(name)) {
           mongoose.connection.db
             .dropCollection(name)
             .catch(err => console.log(err));

--- a/probot/server/tools/update-db.js
+++ b/probot/server/tools/update-db.js
@@ -1,4 +1,4 @@
-const config = require('../config');
+const config = require('../../../config');
 // config should be imported before importing any other file
 const mongoose = require('mongoose');
 
@@ -13,8 +13,8 @@ const db = mongoose.connect(
 );
 
 const { PR, INFO } = require('../models');
-const { getPRs, getUserInput, getFilenames } = require('../../lib/get-prs');
-const { rateLimiter } = require('../../lib/utils');
+const { getPRs, getUserInput, getFilenames } = require('../../../lib/get-prs');
+const { rateLimiter } = require('../../../lib/utils');
 
 const lastUpdate = new Date();
 


### PR DESCRIPTION
This PR fixes a small bug I noticed when trying to run the `seed-db.js` on Digital Ocean.  The user did not have ability to drop the `system.indexes` collection.  Was not an issue when ran locally without authentication.