### PR TITLE
Feat/add english labels to curriculum and guide PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,4 +99,10 @@ build
 # ------------
 
 # work-logs
-# work-logs
+work-logs
+
+# ------------
+# Probot Files
+# ------------
+
+*.pem

--- a/config/index.js
+++ b/config/index.js
@@ -23,10 +23,7 @@ const envVarsSchema = Joi.object({
     .default('false'),
   WEBHOOK_PROXY_URL: Joi.string().required(),
   APP_ID: Joi.number().required(),
-  PRIVATE_KEY: Joi.string().required(),
-  WEBHOOK_SECRET: Joi.string().required(),
-  CLIENT_ID: Joi.string().required(),
-  CLIENT_SECRET: Joi.string().required()
+  WEBHOOK_SECRET: Joi.string().required()
 })
   .unknown()
   .required();
@@ -50,10 +47,7 @@ const config = {
     probot: {
       webhookUrl: envVars.WEBHOOK_PROXY_URL,
       webhookSecret: envVars.WEBHOOK_SECRET,
-      appID: envVars.APP_ID,
-      privateKey: envVars.PRIVATE_KEY,
-      clientID: envVars.CLIENT_ID,
-      clientSecret: envVars.CLIENT_SECRET
+      appID: envVars.APP_ID
     }
   },
   oneoff: {

--- a/config/index.js
+++ b/config/index.js
@@ -18,9 +18,8 @@ const envVarsSchema = Joi.object({
   GITHUB_ACCESS_TOKEN: Joi.string().required(),
   REPOSITORY_OWNER: Joi.string().required(),
   REPOSITORY: Joi.string().required(),
-  PRODUCTION_RUN: Joi.string()
-    .allow(['true', 'false'])
-    .default('false'),
+  PRODUCTION_RUN: Joi.boolean()
+    .default(false),
   WEBHOOK_PROXY_URL: Joi.string().required(),
   APP_ID: Joi.number().required(),
   WEBHOOK_SECRET: Joi.string().required()

--- a/lib/pr-tasks/labeler.js
+++ b/lib/pr-tasks/labeler.js
@@ -3,7 +3,7 @@ const { validLabels } = require('../validation');
 const { addLabels } = require('./add-labels');
 const { rateLimiter } = require('../utils');
 
-const labeler = async (
+const labeler = async(
   number,
   prFiles,
   currentLabels,
@@ -22,7 +22,7 @@ const labeler = async (
       /^curriculum\/challenges\//,
       'curriculum/'
     );
-    const regex = /^(docs|curriculum|guide)(?:\/)(arabic|chinese|portuguese|russian|spanish)?\/?/;
+    const regex = /^(docs|curriculum|guide)(?:\/)(english|arabic|chinese|portuguese|russian|spanish)?\/?/;
     // need an array to pass to labelsAdder
     const [_, articleType, language] = filenameReplacement.match(regex) || [];
     if (articleType && validLabels[articleType]) {
@@ -43,8 +43,8 @@ const labeler = async (
   if (newLabels.length) {
     if (config.oneoff.productionRun) {
       addLabels(number, newLabels);
+      await rateLimiter(1000);
     }
-    await rateLimiter();
   }
   return newLabels;
 };

--- a/lib/validation/guide-folder-checks/index.js
+++ b/lib/validation/guide-folder-checks/index.js
@@ -25,8 +25,9 @@ const guideFolderChecks = async (number, prFiles, user) => {
     const comment = createErrorMsg(prErrors, user);
     if (config.oneoff.productionRun) {
       await addComment(number, comment);
+      await rateLimiter(1000);
     }
-    await rateLimiter();
+
     return comment;
   } else {
     return null;

--- a/lib/validation/valid-labels.js
+++ b/lib/validation/valid-labels.js
@@ -1,6 +1,7 @@
 const validLabels = {
   arabic: 'language: Arabic',
   chinese: 'language: Chinese',
+  english: 'language: English',
   portuguese: 'language: Portuguese',
   russian: 'language: Russian',
   spanish: 'language: Spanish',

--- a/one-off-scripts/add-language-labels-to-files.js
+++ b/one-off-scripts/add-language-labels-to-files.js
@@ -1,10 +1,5 @@
 /*
-This script was originally created to iterate over all open PRs to label and
-comment on specific PR errors (i.e. guide related filenmame syntax and
-frontmatter).
-
-Since the first run which covered over 10,000+ PRs, it is curently ran every
-couple of days for just the most recent PRs.
+This script was created to iterate over all open PRs to label.
 
 To run the script for a specific range (i.e. label and comment on guide errors),
 run `node sweeper.js range startingPrNumber endingPrNumber`

--- a/one-off-scripts/add-language-labels-to-files.js
+++ b/one-off-scripts/add-language-labels-to-files.js
@@ -1,0 +1,64 @@
+/*
+This script was originally created to iterate over all open PRs to label and
+comment on specific PR errors (i.e. guide related filenmame syntax and
+frontmatter).
+
+Since the first run which covered over 10,000+ PRs, it is curently ran every
+couple of days for just the most recent PRs.
+
+To run the script for a specific range (i.e. label and comment on guide errors),
+run `node sweeper.js range startingPrNumber endingPrNumber`
+*/
+
+const { owner, repo, octokitConfig, octokitAuth } = require('../lib/constants');
+
+const octokit = require('@octokit/rest')(octokitConfig);
+
+const { getPRs, getUserInput } = require('../lib/get-prs');
+const { ProcessingLog, rateLimiter } = require('../lib/utils');
+const { labeler } = require('../lib/pr-tasks');
+
+octokit.authenticate(octokitAuth);
+
+const log = new ProcessingLog('add-language-labels');
+
+log.start();
+console.log('Guide and Curriculum File language labeler started...');
+(async() => {
+  const { totalPRs, firstPR, lastPR } = await getUserInput();
+  const prPropsToGet = ['number', 'labels', 'user'];
+  const { openPRs } = await getPRs(totalPRs, firstPR, lastPR, prPropsToGet);
+  let count = 0;
+  if (openPRs.length) {
+    console.log('Processing PRs...');
+    for (let i = 0; i < openPRs.length; i++) {
+      let { number, labels: currentLabels } = openPRs[i];
+      const { data: prFiles } = await octokit.pullRequests.listFiles({
+        owner,
+        repo,
+        number
+      });
+      count++;
+
+      const labelsAdded = await labeler(
+        number,
+        prFiles,
+        currentLabels
+      );
+      const labelLogVal = labelsAdded.length ? labelsAdded : 'none added';
+
+      log.add(number, { number, labels: labelLogVal });
+      if (count > 4000) {
+        await rateLimiter(2350);
+      }
+    }
+  }
+})()
+  .then(() => {
+    log.finish();
+    console.log('Labeler complete');
+  })
+  .catch(err => {
+    log.finish();
+    console.log(err);
+  });

--- a/one-off-scripts/comments-and-labels-summary.js
+++ b/one-off-scripts/comments-and-labels-summary.js
@@ -15,7 +15,7 @@ const dedent = require('dedent');
 
 const specificLogFile = path.resolve(
   __dirname,
-  '../work-logs/test_sweeper_18059-20977_2019-01-03T145413.json'
+  '../work-logs/test_add-language-labels_26001-29000_2019-01-14T215420.json'
 );
 
 (() => {
@@ -24,7 +24,7 @@ const specificLogFile = path.resolve(
 
   let count = 0;
   let prsWithComments = prs.reduce((text, { number, comment, labels }) => {
-    if (comment !== 'none' || labels !== 'none added') {
+    if ((comment && comment !== 'none') || labels !== 'none added') {
       text += dedent`
 
         PR #${number}

--- a/probot/sample.env
+++ b/probot/sample.env
@@ -10,10 +10,8 @@ PRODUCTION_RUN=false
 # PROBOT
 # The ID of your GitHub App
 APP_ID=
-WEBHOOK_SECRET=development
-
-# Use `trace` to get verbose logging or `info` to show less
-LOG_LEVEL=debug
-
 # Go to https://smee.io/new set this to the URL that you are redirected to.
 WEBHOOK_PROXY_URL=
+WEBHOOK_SECRET=
+# Use `trace` to get verbose logging or `info` to show less
+LOG_LEVEL=debug

--- a/probot/server/tools/seed-db.js
+++ b/probot/server/tools/seed-db.js
@@ -31,6 +31,7 @@ db.then(() => {
   });
 
   // get the most recent production data to use locally
+  // NOTE: This url will need to be changed to the new url once off Glitch
   fetch('https://pr-relations.glitch.me/getData', { method: 'GET' })
     .then(response => response.json())
     .then(({ startTime, prs }) => {

--- a/probot/server/tools/update-db.js
+++ b/probot/server/tools/update-db.js
@@ -73,15 +73,25 @@ db.then(async () => {
 })
   .then(async () => {
     // update info collection
-    const prs = await PR.find({});
-    const firstPR = prs[0]._id;
-    const lastPR = prs[prs.length - 1]._id;
+    const [ { firstPR, lastPR }] = await PR.aggregate(
+      [{
+        $group: {
+          _id: null,
+          firstPR: { $min: '$_id' },
+          lastPR: { $max: '$_id' }
+        }
+      }]
+    );
+    const numPRs = await PR.count();
     const info = {
       lastUpdate,
-      numPRs: prs.length,
+      numPRs,
       prRange: `${firstPR}-${lastPR}`
     };
-    await INFO.updateOne(info);
+    await INFO.updateOne(info)
+      .catch(err => {
+        console.log(err);
+      });
     mongoose.connection.close();
   })
   .catch(err => {


### PR DESCRIPTION
This PR adds a new one-off script which only labels Guide and Curriculum related PRs with applicable language.  Basically, I modified sweeper.js and removed the Guide article validation and added `language: English" label to the existing labeler.js script.

This PR also allows us to get off Glitch and use only the Mongo DB. 

**NOTE 1:**  As soon as we make this change, we will need to modify the `seed-db.js` file to no longer get the data from Glitch and instead pull from the production db for seeding local db.  Will make this change in a separate PR.

**NOTE 2:** We will need to update the crontab to reflect the new location of the `update-db.js` script.