### PR TITLE
[Fix] Increased the number of files pulled per PR to Github max of 300

### DIFF
--- a/lib/get-prs/index.js
+++ b/lib/get-prs/index.js
@@ -7,14 +7,24 @@ const { getRange, getCount } = require('./pr-stats');
 
 octokit.authenticate(octokitAuth);
 
-const paginate = async function paginate(
+const methodProps = {
+  owner,
+  repo,
+  state: 'open',
+  base: 'master',
+  sort: 'created',
+  direction: 'asc',
+  page: 1,
+  per_page: 100
+};
+
+const prsPaginate = async(
   method,
-  octokit,
   firstPR,
   lastPR,
   prPropsToGet,
   progressBar
-) {
+) => {
   const prFilter = (prs, first, last, prPropsToGet) => {
     const filtered = [];
     for (let pr of prs) {
@@ -33,17 +43,6 @@ const paginate = async function paginate(
     return filtered;
   };
 
-  const methodProps = {
-    owner,
-    repo,
-    state: 'open',
-    base: 'master',
-    sort: 'created',
-    direction: 'asc',
-    page: 1,
-    per_page: 100
-  };
-
   // will be true when lastPR is seen in paginated results
   let done = false;
   let response = await method(methodProps);
@@ -58,7 +57,7 @@ const paginate = async function paginate(
   return data;
 };
 
-const getUserInput = async (rangeType = '') => {
+const getUserInput = async(rangeType = '') => {
   let data, firstPR, lastPR;
   if (rangeType === 'all') {
     data = await getRange().then(data => data);
@@ -107,9 +106,8 @@ const getPRs = async (totalPRs, firstPR, lastPR, prPropsToGet) => {
     _cliProgress.Presets.shades_classic
   );
   getPRsBar.start(totalPRs, 0);
-  let openPRs = await paginate(
+  let openPRs = await prsPaginate(
     octokit.pullRequests.list,
-    octokit,
     firstPR,
     lastPR,
     prPropsToGet,
@@ -121,13 +119,25 @@ const getPRs = async (totalPRs, firstPR, lastPR, prPropsToGet) => {
   return { firstPR, lastPR, openPRs };
 };
 
-const getFilenames = async number => {
-  const { data: prFiles } = await octokit.pullRequests.listFiles({
-    owner,
-    repo,
-    number
+
+const filesPaginate = async number => {
+  let response = await octokit.pullRequests.listFiles({
+    number, ...methodProps
   });
-  return prFiles.map(({ filename }) => filename);
+
+  let { data } = response;
+  while (octokit.hasNextPage(response)) {
+    response = await octokit.getNextPage(response);
+    let { data: moreData } = response;
+    data = data.concat(moreData);
+  }
+  return data;
 };
 
-module.exports = { getPRs, getUserInput, getFilenames };
+const getFiles = async number => await filesPaginate(number);
+
+const getFilenames = async number => (
+  await getFiles(number)
+).map(({ filename }) => filename);
+
+module.exports = { getPRs, getUserInput, getFiles, getFilenames };

--- a/lib/get-prs/pr-stats.js
+++ b/lib/get-prs/pr-stats.js
@@ -4,70 +4,38 @@ const octokit = require('@octokit/rest')(octokitConfig);
 
 octokit.authenticate(octokitAuth);
 
-const state = 'open';
-const base = 'master';
-const sort = 'created';
-const page = 1;
-const per_page = 1;
+let methodProps = {
+  owner, repo, state: 'open',
+  base: 'master', sort: 'created',
+  page: 1, per_page: 1
+};
 
-const getCount = async () => {
-  const {
-    data: { total_count: count }
-  } = await octokit.search
-    .issues({
+const getCount = async() => {
+  const { data: { total_count: count } } = await octokit.search.issues({
       q: `repo:${owner}/${repo}+is:open+type:pr+base:master`,
-      sort: 'created',
-      order: 'asc',
-      page: 1,
-      per_page: 1
+      sort: 'created', order: 'asc', page: 1, per_page: 1
     })
-    .catch(err => {
-      console.log(err);
-    });
+    .catch(err => console.log(err));
   return count;
 };
 
-const getFirst = async () => {
-  let methodProps = {
-    owner,
-    repo,
-    state,
-    base,
-    sort,
-    direction: 'asc',
-    page,
-    per_page
-  };
-  let response = await octokit.pullRequests.list(methodProps);
+const getFirst = async() => {
+  const response = await octokit.pullRequests.list({
+    direction: 'asc', ...methodProps
+  });
   return response.data[0].number;
 };
 
-const getRange = async () => {
-  let methodProps = {
-    owner,
-    repo,
-    state,
-    base,
-    sort,
-    direction: 'asc',
-    page,
-    per_page
-  };
-  let response = await octokit.pullRequests.list(methodProps);
+const getRange = async() => {
+  let response = await octokit.pullRequests.list({
+    direction: 'asc', ...methodProps
+  });
   const firstPR = response.data[0].number;
-  methodProps = {
-    owner,
-    repo,
-    state,
-    base,
-    sort,
-    direction: 'desc',
-    page,
-    per_page
-  };
-  response = await octokit.pullRequests.list(methodProps);
+  response = await octokit.pullRequests.list({
+    direction: 'desc', ...methodProps }
+  );
   const lastPR = response.data[0].number;
-  return [firstPR, lastPR];
+  return [ firstPR, lastPR ];
 };
 
 module.exports = { getCount, getFirst, getRange };

--- a/one-off-scripts/add-language-labels-to-files.js
+++ b/one-off-scripts/add-language-labels-to-files.js
@@ -5,15 +5,9 @@ To run the script for a specific range (i.e. label and comment on guide errors),
 run `node sweeper.js range startingPrNumber endingPrNumber`
 */
 
-const { owner, repo, octokitConfig, octokitAuth } = require('../lib/constants');
-
-const octokit = require('@octokit/rest')(octokitConfig);
-
-const { getPRs, getUserInput } = require('../lib/get-prs');
+const { getPRs, getUserInput, getFiles } = require('../lib/get-prs');
 const { ProcessingLog, rateLimiter } = require('../lib/utils');
 const { labeler } = require('../lib/pr-tasks');
-
-octokit.authenticate(octokitAuth);
 
 const log = new ProcessingLog('add-language-labels');
 
@@ -28,11 +22,8 @@ console.log('Guide and Curriculum File language labeler started...');
     console.log('Processing PRs...');
     for (let i = 0; i < openPRs.length; i++) {
       let { number, labels: currentLabels } = openPRs[i];
-      const { data: prFiles } = await octokit.pullRequests.listFiles({
-        owner,
-        repo,
-        number
-      });
+
+      const prFiles = await getFiles(number);
       count++;
 
       const labelsAdded = await labeler(

--- a/one-off-scripts/sweeper.js
+++ b/one-off-scripts/sweeper.js
@@ -10,16 +10,10 @@ To run the script for a specific range (i.e. label and comment on guide errors),
 run `node sweeper.js range startingPrNumber endingPrNumber`
 */
 
-const { owner, repo, octokitConfig, octokitAuth } = require('../lib/constants');
-
-const octokit = require('@octokit/rest')(octokitConfig);
-
-const { getPRs, getUserInput } = require('../lib/get-prs');
+const { getPRs, getUserInput, getFiles } = require('../lib/get-prs');
 const { guideFolderChecks } = require('../lib/validation');
 const { ProcessingLog, rateLimiter } = require('../lib/utils');
 const { labeler } = require('../lib/pr-tasks');
-
-octokit.authenticate(octokitAuth);
 
 const log = new ProcessingLog('sweeper');
 
@@ -38,11 +32,7 @@ console.log('Sweeper started...');
         labels: currentLabels,
         user: { login: username }
       } = openPRs[i];
-      const { data: prFiles } = await octokit.pullRequests.listFiles({
-        owner,
-        repo,
-        number
-      });
+      const prFiles = await getFiles(number);
       count++;
 
       const guideFolderErrorsComment = await guideFolderChecks(

--- a/probot/server/routes/pareto.js
+++ b/probot/server/routes/pareto.js
@@ -14,6 +14,7 @@ const createPareto = reportObj =>
 
 router.get('/', async (reqeust, response) => {
   const prs = await PR.find({}).then(data => data);
+  prs.sort((a, b) => a._id - b._id);
   const reportObj = prs.reduce((obj, pr) => {
     const { _id: number, filenames, username, title } = pr;
     filenames.forEach(filename => {

--- a/probot/server/routes/pr.js
+++ b/probot/server/routes/pr.js
@@ -3,6 +3,7 @@ const { PR } = require('../models');
 
 router.get('/:number', async (request, response) => {
   const prs = await PR.find({}).then(data => data);
+  prs.sort((a, b) => a._id - b._id);
   const indices = prs.reduce((obj, { _id }, index) => {
     obj[_id] = index;
     return obj;

--- a/probot/server/routes/search.js
+++ b/probot/server/routes/search.js
@@ -3,6 +3,7 @@ const { PR } = require('../models');
 
 router.get('/', async (request, response) => {
   const prs = await PR.find({}).then(data => data);
+  prs.sort((a, b) => a._id - b._id);
   const indices = prs.reduce((obj, { _id }, index) => {
     obj[_id] = index;
     return obj;


### PR DESCRIPTION
Noticed an issue with the fact that the Github API defaults to 30 files per PR request using the applicable end point.  I modified the getFilenames function to pull the maximum of 300 (as allowed via the API).  

**NOTE:**  The fact that some PRs could touch more than 300, means that the Pareto View may not always reflect the correct count of PRs per file, if there are PRs with more than 300 files, as some of the files would not be included in the calculations.  It is very rare that these kind of PRs would exist and when they do appear, there would be a lot of attention anyway on when to merge it.  It could mean, we need to create some kind of special label to draw attention to PRs which return 300 files during execution of  `sweeper.js` .

Also, we are now pulling the data from Mongo instead of a data file (which was already sorted), so I had to sort the PR numbers before returning the response, anytime a list of PRs is displayed, Now they correctly display in ascending order as they did before the move to Mongo.