### PR TITLE
Fix broken link of contribution guide

### DIFF
--- a/probot/public/index.html
+++ b/probot/public/index.html
@@ -130,7 +130,7 @@
           <tr>
             <td class="text-center"><i class="fa fa-github"></i></td>
             <td>
-              <a href="https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md" target="_blank">Contribute to the codebase</a>
+              <a href="https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md" target="_blank">Contribute to the codebase</a>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
The link to contribution guide wasn't pointing to the actual CONTRIBUTING doc in `freeCodeCamp/freeCodeCamp/CONTRIBUTING.md`.