### PR TITLE
[Fix] Corrected client page title typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,10 +15,14 @@ npm install
 
 npm run build
 
-npm run dev
+npm run develop
 ```
 
 ## Caveats & Notes
+
+### Local Ports when developing locally
+
+Using the above `npm run develop` will start both the api server and the Create React App (Dashboard) in development mode.  The api server runs on port 3001 and the React app runs on port 3000.  
 
 ### The one-off scripts will error out on actions performed by repository admins, for example:
 

--- a/probot/client/public/index.html
+++ b/probot/client/public/index.html
@@ -18,7 +18,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>freeCodeCamp Cpntributor Tools</title>
+    <title>freeCodeCamp Contributor Tools</title>
   </head>
   <body>
     <noscript>

--- a/probot/server/tools/update-db.js
+++ b/probot/server/tools/update-db.js
@@ -44,6 +44,7 @@ db.then(async () => {
     if (!oldIndices.hasOwnProperty(number)) {
       // insert a new pr
       const filenames = await getFilenames(number);
+      count++;
       await PR.create({ _id: number, updatedAt, title, username, filenames });
       console.log('added PR# ' + number);
     } else if (updatedAt > oldUpdatedAt) {

--- a/probot/server/tools/update-db.js
+++ b/probot/server/tools/update-db.js
@@ -86,7 +86,7 @@ db.then(async () => {
       numPRs,
       prRange: `${firstPR}-${lastPR}`
     };
-    await INFO.updateOne(info)
+    await INFO.updateOne({}, info, { upsert: true })
       .catch(err => {
         console.log(err);
       });


### PR DESCRIPTION
This PR fixes a typo in the Dashboards title.

This PR also fixes a small bug where if the local db does not already have an `info` collection, the record is added instead of updated.

Other minor fixes:

1. Incremented `count` variable when new PRs are added, because the `getFiles` goes against the rate limit.

2. Updated documentation regarding local development ports used.


Closes #80 