### PR TITLE
Fix: Added ability to specify language when searching for PRs with an unknown repo and merge conflicts

### DIFF
--- a/one-off-scripts/get-unknown-repo-prs.js
+++ b/one-off-scripts/get-unknown-repo-prs.js
@@ -1,3 +1,14 @@
+/*
+This script was created to find all open PRs with unknown repos which 
+potentially have merge conflicts.
+
+To run the script for a specific language, call the script with the language
+name as the first argument.
+
+Note: If any PR displayed in the console shows "unknown", you will need to rerun
+the script again.
+*/
+
 const { owner, repo, octokitConfig, octokitAuth } = require('../lib/constants');
 const octokit = require('@octokit/rest')(octokitConfig);
 
@@ -8,8 +19,9 @@ const { validLabels } = require('../lib/validation/valid-labels');
 octokit.authenticate(octokitAuth);
 
 let languageLabel;
-const [languageArg] = process.argv.slice(2);
+let [languageArg] = process.argv.slice(2);
 if (languageArg) {
+  languageArg = languageArg.toLowerCase();
   languageLabel = validLabels[languageArg] ? validLabels[languageArg] : null;
 }
 
@@ -25,6 +37,8 @@ log.start();
   const { openPRs } = await getPRs(totalPRs, firstPR, lastPR, prPropsToGet);
   if (openPRs.length) {
     let count = 0;
+    let mergeConflictCount = 0;
+
     for (let i = 0; i < openPRs.length; i++) {
       let { labels, number, head: { repo: headRepo } } = openPRs[i];
 
@@ -32,22 +46,27 @@ log.start();
         ({ name }) => languageLabel === name
       );
 
-      if (headRepo === null && (!languageLabel || hasLanguage )) {        
-        const {
-          data: { mergeable_state: mergeableState }
-        } = await octokit.pullRequests.get({ owner, repo, number });
+      if (headRepo === null && (!languageLabel || hasLanguage )) {
+        let data = await octokit.pullRequests.get({ owner, repo, number });
+        let mergeableState = data.data.mergeable_state;
+        if (mergeableState === 'unknown') {
+          await rateLimiter(4000); // allow time to let GitHub determine status
+          data = await octokit.pullRequests.get({ owner, repo, number });
+          mergeableState = data.data.mergeable_state;
+        }
         count++;
 
         if (mergeableState === 'dirty' || mergeableState === 'unknown') {
           log.add(number, { number, mergeableState });
           console.log(`${number} (${mergeableState})`);
+          mergeConflictCount++;
         }
         if (count > 4000) {
           await rateLimiter(2350);
         }
       }
     }
-    console.log(`There were ${count} PRs with unknown repos received from GitHub`);
+    console.log(`There were ${mergeConflictCount} PRs with potential merge conflicts out of ${count} unknown repos received from GitHub`);
   } else {
     throw 'There were no open PRs received from Github';
   }


### PR DESCRIPTION
This PR makes a few improvements to the existing one-off script that finds PRs with an unknown repo and potential merge conflicts.

PR actions:
* Added a comment describing the scripts purpose and usage.
* Added ability to specify a language (for curriculum, documentation, and guide related PRs).
* Added an additional call to get the merge status in case GitHub was unable to determine during first call.
* Added/Modified some informational console.log statements.