### PR TITLE
feature: Added new script to find all open PRs with merge conflicts

### DIFF
--- a/one-off-scripts/prs-with-merge-conflicts.js
+++ b/one-off-scripts/prs-with-merge-conflicts.js
@@ -1,0 +1,84 @@
+/*
+This script was created to find all open PRs that potentially have merge
+conflicts.
+
+To run the script for a specific language, call the script with the language
+name as the first argument.
+
+Note: If any PR displayed in the console shows "unknown", you will need to rerun
+the script again.
+*/
+
+const { owner, repo, octokitConfig, octokitAuth } = require('../lib/constants');
+const octokit = require('@octokit/rest')(octokitConfig);
+
+const { getPRs, getUserInput } = require('../lib/get-prs');
+const { ProcessingLog, rateLimiter } = require('../lib/utils');
+const { validLabels } = require('../lib/validation/valid-labels');
+
+octokit.authenticate(octokitAuth);
+
+let languageLabel;
+let [languageArg] = process.argv.slice(2);
+if (languageArg) {
+  languageArg = languageArg.toLowerCase();
+  languageLabel = validLabels[languageArg] ? validLabels[languageArg] : null;
+}
+
+if (languageLabel) {
+  console.log(`finding PRs with label = ${languageLabel}`);
+}
+
+const log = new ProcessingLog('prs-with-merge-conflicts');
+log.start();
+(async () => {
+  const { totalPRs, firstPR, lastPR } = await getUserInput('all');
+  const prPropsToGet = ['number', 'labels', 'user'];
+  const { openPRs } = await getPRs(totalPRs, firstPR, lastPR, prPropsToGet);
+  if (openPRs.length) {
+    let count = 0;
+    for (let i = 0; i < openPRs.length; i++) {
+      let { labels, number } = openPRs[i];
+
+      const hasLanguage = languageLabel && labels.some(
+        ({ name }) => languageLabel === name
+      );
+
+      const hasMergeConflictLabel = labels.some(
+        ({ name }) => "status: merge conflict" === name
+      );
+
+      if (!languageLabel || hasLanguage) {
+        let data = await octokit.pullRequests.get({ owner, repo, number }); 
+        let mergeableState = data.data.mergeable_state;
+        count++;     
+        if (mergeableState === 'unknown') {
+          await rateLimiter(4000);
+          data = await octokit.pullRequests.get({ owner, repo, number });
+          mergeableState = data.data.mergeable_state;
+          count++;
+        }
+        
+        if (mergeableState === 'dirty' && !hasMergeConflictLabel) {
+          log.add(number, { number, mergeableState });
+          console.log(`${number} (${mergeableState}) - might need a merge conflict label`);
+        }
+        
+        if (count > 4000) {
+          await rateLimiter(2350);
+        }
+      }
+    }
+    console.log(`There were ${count} PRs with potential merge conflicts out of ${count} PRs received from GitHub`);
+  } else {
+    throw 'There were no open PRs received from Github';
+  }
+})()
+  .then(async () => {
+    log.finish();
+    console.log('Finished finding PRs with merge conflicts');
+  })
+  .catch(err => {
+    log.finish();
+    console.log(err);
+  });


### PR DESCRIPTION
This PR adds a new one-off script which finds all open PRs with merge conflicts.  You can optionally specify a language as the first argument and it will only check PRs with an existing language label which matches.

I have been using this to help me identify PRs with merge conflicts which have not been labeled as yet.  If this script is found to be useful, it could be enhanced to go ahead and add the `status: merge conflict` label to the PR when it is ran.