### PR TITLE
fix: add PR number to message displayed when there are no search results for a PR number

### DIFF
--- a/probot/server/routes/pr.js
+++ b/probot/server/routes/pr.js
@@ -14,7 +14,7 @@ router.get('/:number', async (request, response) => {
   if (!index && index !== 0) {
     response.json({
       ok: true,
-      message: 'Unable to find that open PR #.',
+      message: `Unable to find an open PR with #${refNumber}.`,
       results: []
     });
     return;


### PR DESCRIPTION
Closes #87 

The title of this PR sums up the changes.