### PR TITLE
feat: prep for deployment on root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# contribute
+# tools
 
 Tools to help maintain [freeCodeCamp.org](https://www.freecodecamp.org)'s Open Source Codebase on GitHub. Dashboard is available at <https://tools.freecodecamp.org/home>
+
+## How to use
+
+See [README.md](docs/README.md) for how to run locally.
 
 ### Credits
 

--- a/dashboard-app/client/package.json
+++ b/dashboard-app/client/package.json
@@ -15,7 +15,6 @@
   "bugs": {
     "url": "https://github.com/freeCodeCamp/freeCodeCamp/issues"
   },
-  "homepage": "https://github.com/freeCodeCamp/freeCodeCamp#readme",
   "author": "freeCodeCamp <team@freecodecamp.org>",
   "main": "none",
   "scripts": {


### PR DESCRIPTION
Removing "homepage" from package.json stops CRA from creating relative paths for all the built assets.
